### PR TITLE
fix: remove fetch polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,10 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "@remix-run/dev@2.3.0": "patches/@remix-run__dev@2.3.0.patch"
+    }
   }
 }

--- a/patches/@remix-run__dev@2.3.0.patch
+++ b/patches/@remix-run__dev@2.3.0.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/vite/node/adapter.js b/dist/vite/node/adapter.js
+index c6f7097c1257ff59652836db54426030120881de..27dbc0d42d03ebfb91dccc5c8f62b699e0d484d4 100644
+--- a/dist/vite/node/adapter.js
++++ b/dist/vite/node/adapter.js
+@@ -25,7 +25,7 @@ function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'defau
+ var multipart__default = /*#__PURE__*/_interopDefaultLegacy(multipart);
+ 
+ // @ts-nocheck
+-node.installGlobals();
++// node.installGlobals();
+ function nodeToWeb(nodeStream) {
+   let destroyed = false;
+   let listeners = {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@remix-run/dev@2.3.0':
+    hash: nvr6e5cjdle7e3aj52shuc7yje
+    path: patches/@remix-run__dev@2.3.0.patch
+
 dependencies:
   '@remix-run/node':
     specifier: ^2.3.0
@@ -27,7 +32,7 @@ dependencies:
 devDependencies:
   '@remix-run/dev':
     specifier: ^2.3.0
-    version: 2.3.0(@remix-run/serve@2.3.0)(typescript@5.2.2)(vite@5.0.0)
+    version: 2.3.0(patch_hash=nvr6e5cjdle7e3aj52shuc7yje)(@remix-run/serve@2.3.0)(typescript@5.2.2)(vite@5.0.0)
   '@remix-run/eslint-config':
     specifier: ^2.3.0
     version: 2.3.0(eslint@8.53.0)(react@18.2.0)(typescript@5.2.2)
@@ -1278,7 +1283,7 @@ packages:
     dev: true
     optional: true
 
-  /@remix-run/dev@2.3.0(@remix-run/serve@2.3.0)(typescript@5.2.2)(vite@5.0.0):
+  /@remix-run/dev@2.3.0(patch_hash=nvr6e5cjdle7e3aj52shuc7yje)(@remix-run/serve@2.3.0)(typescript@5.2.2)(vite@5.0.0):
     resolution: {integrity: sha512-Eno0XHyIKo5GyzN4OAwNkgkyl4H1mLWbqeVUA8T5HmVDj+8qJLIcYeayS2BmA1KYAHJBiy5ufAGi2MpaXMjKww==}
     engines: {node: '>=18.0.0'}
     hasBin: true
@@ -1368,6 +1373,7 @@ packages:
       - ts-node
       - utf-8-validate
     dev: true
+    patched: true
 
   /@remix-run/eslint-config@2.3.0(eslint@8.53.0)(react@18.2.0)(typescript@5.2.2):
     resolution: {integrity: sha512-iyuNO7tRjevLjwGH4nLv/6g5NROhUXIQHTNjTUhQjEkHac4/kp3EOnnQEtGmMUfLruTyz6OoOJQzTkT3l14VvQ==}


### PR DESCRIPTION
Node already has global `fetch`, `Request`, etc... since node 18, so maybe polyfill could be removed if remix can give up supporting node 16.