### PR TITLE
fix: enforce non-http2 for https by empty "server.proxy"

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import tsconfigPaths from "vite-tsconfig-paths";
 export default defineConfig({
   plugins: [remix(), tsconfigPaths()],
   server: {
+    proxy: {},
     https: {
       key: "localhost-key.pem",
       cert: "localhost.pem",


### PR DESCRIPTION
Also, it can easily workaround by vite config.